### PR TITLE
Feature/lyrics realtime

### DIFF
--- a/MusicWith/Control/LyricsView.swift
+++ b/MusicWith/Control/LyricsView.swift
@@ -10,6 +10,9 @@ import SwiftUI
 struct LyricsView: View {
     @StateObject var controlState = ControlState.shared
     @State       var lyric        = ""
+    @State       var beginList: [Int]   = []
+    @State       var lineList: [String]     = []
+    @Environment(\.colorScheme) var colorSchema
 
     var body: some View {
         if let state = controlState.playState {
@@ -18,14 +21,26 @@ struct LyricsView: View {
                     .padding(.top, 30)
                     .font(.system(size: 20, weight: .semibold))
                 ScrollView {
-                    Text(lyric)
+                    ForEach(0..<min(beginList.count, lineList.count), id: \.self) { index in
+                        if beginList.count-1 == index { //마지막 요소
+                            Text(lineList[index])
+                                .foregroundColor(beginList[index]<=Int(state.now) ? Color.blue : colorSchema == .dark ? .white : .black)
+                                .padding()
+                        }
+                        else {
+                            Text(lineList[index])
+                                .foregroundColor(beginList[index]<=Int(state.now) ? Color.blue : colorSchema == .dark ? .white : .black)
+                                .padding()
+                        }
+                    }
+                    /*Text(lyric)
                         .lineSpacing(30)
                         .offset(y:30)
-                        .padding(30)
+                        .padding(30)*/
                 }
             }
             .task {
-                lyric = await state.song.lyric() ?? ""
+                (beginList, lineList) = await state.song.lyric() ?? ([],[])
             }
         }
     }

--- a/MusicWith/Control/LyricsView.swift
+++ b/MusicWith/Control/LyricsView.swift
@@ -33,14 +33,10 @@ struct LyricsView: View {
                                 .padding()
                         }
                     }
-                    /*Text(lyric)
-                        .lineSpacing(30)
-                        .offset(y:30)
-                        .padding(30)*/
                 }
             }
             .task {
-                (beginList, lineList) = await state.song.lyric() ?? ([],[])
+                (beginList, lineList) = await state.song.lyric() ?? ([0],["loading"])
             }
         }
     }

--- a/MusicWith/Control/LyricsView.swift
+++ b/MusicWith/Control/LyricsView.swift
@@ -18,7 +18,7 @@ struct LyricsView: View {
         if let state = controlState.playState {
             VStack {
                 Text("가사")
-                    .padding(.top, 30)
+                    .padding(.top, 10)
                     .font(.system(size: 20, weight: .semibold))
                 ScrollView {
                     ForEach(0..<min(beginList.count, lineList.count), id: \.self) { index in
@@ -29,7 +29,7 @@ struct LyricsView: View {
                         }
                         else {
                             Text(lineList[index])
-                                .foregroundColor(beginList[index]<=Int(state.now) ? Color.blue : colorSchema == .dark ? .white : .black)
+                                .foregroundColor(beginList[index]<=Int(state.now) && Int(state.now) < beginList[index+1] ? Color.blue : colorSchema == .dark ? .white : .black)
                                 .padding()
                         }
                     }

--- a/MusicWith/Util/Spotify/SpotifyTrack.swift
+++ b/MusicWith/Util/Spotify/SpotifyTrack.swift
@@ -9,13 +9,13 @@ import Foundation
 // https://developer.spotify.com/documentation/web-api/reference/get-track
 class SpotifyTrack {
     private var _storage: [String: Any] = [:]
-    private var _lyric  : String?
+    private var _lyric  : ([Int], [String])?
 
     let trackId : String
     let imageURL: String? // storage 에 넣은 후 함수로 받아올 경우 무한 loading 이 걸림 => await 안 쓰게 구현시도
     let title   : String?
 
-    init(trackId: String, name: String? = nil, artist: String? = nil, imageUrl: String? = nil, songUrl: String? = nil, lyric: String? = nil) {
+    init(trackId: String, name: String? = nil, artist: String? = nil, imageUrl: String? = nil, songUrl: String? = nil, lyric: ([Int], [String])? = nil) {
         self.trackId                = trackId
         self._lyric                 = lyric
         self._storage[ "name"     ] = name
@@ -81,7 +81,7 @@ class SpotifyTrack {
 
     func lyric() async -> ([Int], [String])? {
         if let lyric = _lyric {
-            return ([],[])
+            return lyric
         }
 
         guard let url = URL(string: "http://localhost:8000/lyrics?track_id=\(trackId)") else {
@@ -99,7 +99,7 @@ class SpotifyTrack {
         
         var beginList: [Int] = []
         var lineList: [String] = []
-        var lineMerged = ""
+        //var lineMerged = ""
 
         for line in lines {
             guard let begin   = line[ "begin"   ] as? Int,
@@ -108,10 +108,10 @@ class SpotifyTrack {
             }
             beginList.append(begin/1000)
             lineList.append(content)
-            lineMerged += content + "\n"
+            //lineMerged += content + "\n"
         }
 
-        _lyric = lineMerged
+        _lyric = (beginList, lineList)
         return (beginList, lineList)
     }
 }

--- a/MusicWith/Util/Spotify/SpotifyTrack.swift
+++ b/MusicWith/Util/Spotify/SpotifyTrack.swift
@@ -79,9 +79,9 @@ class SpotifyTrack {
         return await load(key: "songUrl") as? String
     }
 
-    func lyric() async -> String? {
+    func lyric() async -> ([Int], [String])? {
         if let lyric = _lyric {
-            return lyric
+            return ([],[])
         }
 
         guard let url = URL(string: "http://localhost:8000/lyrics?track_id=\(trackId)") else {
@@ -96,7 +96,9 @@ class SpotifyTrack {
               let lines = json[ "lines" ] as? [[String: Any]] else {
             return nil
         }
-
+        
+        var beginList: [Int] = []
+        var lineList: [String] = []
         var lineMerged = ""
 
         for line in lines {
@@ -104,11 +106,12 @@ class SpotifyTrack {
                   let content = line[ "content" ] as? String else {
                 return nil
             }
-
+            beginList.append(begin/1000)
+            lineList.append(content)
             lineMerged += content + "\n"
         }
 
         _lyric = lineMerged
-        return lineMerged
+        return (beginList, lineList)
     }
 }


### PR DESCRIPTION
- 현재 재생중인 부분의 가사가 표시됩니다.
  - playstate.now와 begin을 비교하여 재생중인 부분의 가사를 파란색으로 표시합니다.
  - spotifyTrack의 _lyrics의 타입이 String? -> ([Int], [String])으로 변경되었습니다.
  - beginList: [Int]는 begin time들을 담는 배열, lineList: [String]은 가사 한 줄을 담는 배열입니다. 두 배열의 크기는 같습니다.